### PR TITLE
Allow text-based seeds

### DIFF
--- a/1FMMods/scripts/1fmRandoSomeLogic.lua
+++ b/1FMMods/scripts/1fmRandoSomeLogic.lua
@@ -245,11 +245,27 @@ function ItemCompatibility(i, r)
 	return true
 end
 
+-- simple string hashing algorithm designed by Daniel J. Bernstein
+function Djb2(str)
+	hash = 5381
+
+	for c in string.gmatch(str, '.') do
+		hash = ((hash << 5) + hash) + string.byte(c)
+	end
+
+	return hash
+end
+
 function Randomize()
 	successfulRando = false
 	seedfile = io.open("seed.txt", "r")
 	if seedfile ~= nil then
-		math.randomseed(tonumber(seedfile:read()))
+		text = seedfile:read()
+		seed = tonumber(text)
+		if seed == nil then
+			seed = Djb2(text)
+		end
+		math.randomseed(seed)
 		print("Found existing seed")
 	else
 		seedfile = io.open("seed.txt", "w")


### PR DESCRIPTION
This uses Daniel J. Bernstein's `djb2` non-cryptographic string hashing algorithm in order to generate an integer from a string, to enable text-based seeds in `seeds.txt`. This allows users to 'name' their seeds the way many of them expect in a similar fashion to various other randomizers/games. The seed is only transformed into a hash if the contents of the file are not able to be interpreted as a number, so this is completely backwards compatible with old seeds and will not behave any different if it doesn't need to.