### PR TITLE
Remake EarlySkip with ASM Logic Edits for stability.

### DIFF
--- a/1FMMods/scripts/1fmEarlySkip.lua
+++ b/1FMMods/scripts/1fmEarlySkip.lua
@@ -1,6 +1,3 @@
-local lastInput = 0
-local bufferPause = 0
-
 local canExecute = false
 
 function _OnInit()
@@ -13,27 +10,8 @@ function _OnInit()
 end
 
 function _OnFrame()
-	nowInput = ReadInt(0x233D034-0x3A0606)
-	if canExecute and ReadInt(0x233AE74-0x3A0606)==1 then
-		if bufferPause == 2 then
-			WriteInt(0x22E86C8-0x3A0606, 0) --pause
-			bufferPause = 0
-		elseif bufferPause == 1 then
-			--WriteInt(0x232A670-0x3A0606, 1787424224) --skip
-			WriteInt(0x22E86C8-0x3A0606, 1) --pause
-			bufferPause = 2
-		elseif nowInput == 8 and lastInput == 0 and bufferPause == 0 then
-			WriteInt(0x233C49C-0x3A0606, 0) --white screen off
-			WriteInt(0x233C450-0x3A0606, 128) --canskip
-			WriteInt(0x233C454-0x3A0606, 128) --canskip
-			WriteInt(0x233C458-0x3A0606, 128) --canskip
-			WriteInt(0x233C45C-0x3A0606, 128) --canskip
-			WriteInt(0x233C5B8-0x3A0606, 0) --canskip
-			WriteInt(0x233CAA0-0x3A0606, 0) --canskip
-			WriteInt(0x233CAA4-0x3A0606, 0) --canskip
-			bufferPause = 1
-		end
+	if canExecute == true then
+		WriteArray(0x7FF77252ACF3, { 0xEB, 0x10 }, true)
+		WriteArray(0x7FF772525EAC, { 0x0F, 0x96, 0xC0 }, true)
 	end
-	
-	lastInput = nowInput
 end

--- a/1FMMods/scripts/1fmRandoSomeLogic.lua
+++ b/1FMMods/scripts/1fmRandoSomeLogic.lua
@@ -2412,7 +2412,7 @@ function _OnFrame()
 		menuWas = menuNow
 	end
 
-	if stackAbilities > 0 then
+	if stackAbilities > 0 and ReadLong(closeMenu) == 0x00 then
 		StackAbilities()
 	end
 	


### PR DESCRIPTION
This PR simply contains a re-written EarlySkip script, which uses ASM Logic Editing to bypass the game's value checks to allow pausing and skipping cutscenes when in fade.

Tested extensively. But more tests may be necessary.

Requires LuaEngine v5.0 or higher.