### PR TITLE
Disallow stacking abilities whilst in menu to save cycles and enable compatibility with mods.

### DIFF
--- a/1FMMods/scripts/1fmRandoSomeLogic.lua
+++ b/1FMMods/scripts/1fmRandoSomeLogic.lua
@@ -2412,7 +2412,7 @@ function _OnFrame()
 		menuWas = menuNow
 	end
 
-	if stackAbilities > 0 then
+	if stackAbilities > 0 and ReadLong(closeMenu) == 0x00 then
 		StackAbilities()
 	end
 	


### PR DESCRIPTION
**Purpose:**
The purpose of this PR is mainly to enable compatibility with mods which edit the menu in a cosmetic fashion, such as 1fmGrowthMerger.

**Compatibility:**
This PR is compatible with the project and will not cause any bugs or malfunctions.

**Additional Benefits:**
- It will save some cycles during the menus.
- It allows for other mods to be made which edit the menu, specifically player abilities.
