### PR TITLE
Slight bug fixes for those who use less splits

### DIFF
--- a/LoadRemovers/KH1.asl
+++ b/LoadRemovers/KH1.asl
@@ -73,6 +73,7 @@ startup
 	settings.Add("behemoth", true, "Split on Behemoth", "main_splits");
 	settings.Add("cher", true, "Split on Arch Chernabog", "main_splits");
 	settings.Add("a2", true, "Split on Ansem 2", "main_splits");
+	settings.Add("a4", true, "Split on Ansem 4", "main_splits");
 
 	settings.Add("optional_splits", true, "All other Any % splits");
 	settings.Add("shadows_1", false, "Split after clearing Shadows 1 (first full group)", "optional_splits");
@@ -173,153 +174,138 @@ split
 	vars.summontimer = current.summonload ? vars.summontimer + (current.paused ? 0 : 1) : 0;
 	// station of awakening splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 0)){
-		if(settings["shadows_1"] && current.room == 2 && old.room == 1 && vars.shadows_1 == 0){
+		if(current.room == 2 && old.room == 1 && vars.shadows_1 == 0){
 			vars.shadows_1 = 1;
-				return true;
+				return settings["shadows_1"];
 		}
-		if(settings["shadows_2"] && current.sora_level == 2 && current.room == 4 && (current.text_progress == 0 && old.text_progress > 0) && vars.shadows_2 == 0){
+		if(current.sora_level == 2 && current.room == 4 && (current.text_progress == 0 && old.text_progress > 0) && vars.shadows_2 == 0){
 			vars.shadows_2 = 1;
-				return true;
+				return settings["shadows_2"];
 		}
-		if(settings["ds1"] && ((current.fightend == 2 && old.fightend == 0) || (current.hp == 0 && old.hp > 0)) && current.room == 4 && vars.ds1 == 0){
+		if((current.fightend == 2 && old.fightend == 0) || (current.hp == 0 && old.hp > 0) && current.room == 4 && vars.ds1 == 0){
 			vars.shadows_1 = 1;
-				return true;
+				return settings["ds1"];
 		}
 	}
 	// destiny islands splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 1)){
-		if(settings["day_1"] && current.room == 3 && old.room == 0 && vars.day_1 == 0) {
+		if(current.room == 3 && old.room == 0 && vars.day_1 == 0) {
 			vars.day_1 = 1;
-			return true;
+			return settings["day_1"];
 		}
-		if(settings["destiny"] && old.room == 2 && current.room == 3 && current.scene == 2 && vars.destiny == 0) {
+		if(old.room == 2 && current.room == 3 && current.scene == 2 && vars.destiny == 0) {
 			vars.destiny = 1;
-			return true;
+			return settings["destiny"];
 		}
-		if(settings["ds2"] && (current.fightend == 2 && old.fightend == 0) && vars.ds2 == 0) {
+		if((current.fightend == 2 && old.fightend == 0) && vars.ds2 == 0) {
 			vars.ds2 = 1;
-			return true;
+			return settings["ds2"];
 		}
 	}
 	// traverse town splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 3)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["guard"] && current.room == 2 && vars.guard == 0){
+			if(current.room == 2 && vars.guard == 0){
 				vars.guard = 1;
-				return true;
+				return settings["guard"];
 			}
-			if(current.room == 1 && vars.oppo == 0){
-				if(settings["fake_guard"] && settings["oppo"]) {
-					if(vars.fake_guard == 0) {
-						vars.fake_guard = 1;
+			if(current.room == 1){
+				if(vars.fake_guard == 0) {
+					vars.fake_guard = 1;
+					if (settings["manual_back_step"]){
 						vars.back_split = "fake";
-					} else {
-						vars.oppo = 1;
+					}
+					return settings["fake_guard"];
+				} else if (vars.oppo == 0) {
+					if (!settings["manual_back_step"] && vars.deathcounter == 1) {
+						vars.deathcounter = 0;
+						return;
+					} else if (settings ["manual_back_step"]) {
 						vars.back_split = "";
 					}
-					return true;
-				} else if(settings["fake_guard"] && !settings["oppo"]) {
-					vars.back_split = "fake";
 					vars.oppo = 1;
-					return true;
-				} else if(!settings["fake_guard"] && settings["oppo"]) {
-					if(vars.fake_guard == 0) {
-						vars.fake_guard = 1;
-						vars.back_split = "fake";
-						return false;
-					}
-					vars.back_split = "";
-					vars.oppo = 1;
-					return true;
+					return settings["oppo"];
 				}
 			}
 		}
-		if(settings["leon"] && current.room == 0 && current.scene == 3 && vars.leon == 0 && (
+		if(current.room == 0 && current.scene == 3 && vars.leon == 0 && (
 				(current.hp == 0 && old.hp > 0) || (current.white > 0 && old.white == 0)
 			)
 		){
 			vars.leon = 1;
-			return true;
+			return settings["leon"];
 		}
-		if(settings["tt_2"] && vars.tt_2 == 0 && current.room == 10 && current.scene == 11 && current.in_gummi > 0){
+		if(vars.tt_2 == 0 && current.room == 10 && current.scene == 11 && current.in_gummi > 0){
 			vars.tt_2 = 1;
-			return true;
+			return settings["tt_2"];
 		}
-		if(settings["tt_4"] && vars.tt_4 == 0){
+		if(vars.tt_4 == 0){
 			if(old.room == 32 && current.room == 22 && !vars.got_oath){
 				vars.got_oath = true;
-				return false;
 			}
 			if(current.scene == 0 && current.room == 10 && current.in_gummi > 0 && vars.got_oath){
 				vars.tt_4 = 1;
-				return true;
+				return settings["tt_4"];
 			}
 		}
-		if(settings["power_boost"] && vars.torn_page_power_split == 0){
+		if(vars.torn_page_power_split == 0){
 			if(vars.checkWorldValue(old.w1, old.w2, old.w3, old.w4, old.w5, old.w6, old.w7, old.w8, 6) && vars.torn_page_power == 1){
 				vars.torn_page_power_split = 1;
-				return true;
+				return settings["power_boost"];
 			}
 		}
-		if(settings["seal_100_aw"] && vars.muddy_finish == 1 && vars.seal_100_aw == 0){
+		if(vars.muddy_finish == 1 && vars.seal_100_aw == 0){
 			vars.seal_100_aw = 1;
-			return true;
+			return settings["seal_100_aw"];
 		}
 	}
 	// wonderland splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 4)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["crank"] && current.room == 3 && vars.crank == 0){
+			if(current.room == 3 && vars.crank == 0){
 				vars.crank = 1;
-				return true;
+				return settings["crank"];
 			}
-			if(settings["tm"] && current.room == 1 && vars.tm == 0){
+			if(current.room == 1 && vars.tm == 0){
 				vars.tm = 1;
-				return true;
+				return settings["tm"];
 			}
 		}
 	}
 	// deep jungle splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 5)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["sabor_2"] && current.room == 2 && vars.sabor_2 == 0){
+			if(current.room == 2 && vars.sabor_2 == 0){
 				vars.sabor_2 = 1;
-				return true;
+				return settings["sabor_2"];
 			}
-			if(current.room == 11 && vars.clayton_2 == 0){
-				if(settings["clayton_1"] && settings["clayton_2"]) {
-					if(vars.clayton_1 == 0) {
-						vars.clayton_1 = 1;
+			if(current.room == 11){
+				if(vars.clayton_1 == 0) {
+					vars.clayton_1 = 1;
+					if (settings["manual_back_step"]){
 						vars.back_split = "clay1";
-					} else {
-						vars.clayton_2 = 1;
+					}
+					return settings["clayton_1"];
+				} else if (vars.clayton_2 == 0){
+					if (!settings["manual_back_step"] && vars.deathcounter == 1) {
+						vars.deathcounter = 0;
+						return;
+					} else if (settings ["manual_back_step"]) {
 						vars.back_split = "";
 					}
-					return true;
-				} else if(settings["clayton_1"] && !settings["clayton_2"]) {
-					vars.back_split = "clay1";
 					vars.clayton_2 = 1;
-					return true;
-				} else if(!settings["clayton_1"] && settings["clayton_2"]) {
-					if(vars.clayton_1 == 0) {
-						vars.clayton_1 = 1;
-						vars.back_split = "clay1";
-						return false;
-					}
-					vars.back_split = "";
-					vars.clayton_2 = 1;
-					return true;
+					return settings["clayton_2"];
 				}
 			}
 		}
-		if(settings["sabor_1"] && current.room == 0 && current.scene == 0 && vars.sabor_1 == 0 && (
+		if(current.room == 0 && current.scene == 0 && vars.sabor_1 == 0 && (
 				(current.hp == 0 && old.hp > 0) || (current.white > 0 && old.white == 0)
 			) 
 		){
 			vars.sabor_1 = 1;
-			return true;
+			return settings["sabor_1"];
 		}
-		if(settings["power_wilds"] && vars.pw == 0){
+		if(vars.pw == 0){
 			if(current.room == 0 && current.scene == 3 && current.house_gummi != old.house_gummi && !vars.house_gummi) {
 				vars.house_gummi = true;
 			}
@@ -342,229 +328,221 @@ split
 				vars.cliff_gummi = false;
 				vars.camp_gummi = false;
 				vars.pw = 1;
-				return true;
+				return settings["power_wilds"];
 			}
 		}
-		if(settings["wfc"] && vars.wfc == 0 && current.room == 10 && current.scene == 0){
+		if(vars.wfc == 0 && current.room == 10 && current.scene == 0){
 			vars.wfc = 1;
-			return true;
+			return settings["wfc"];
 		}
 	}
 	// 100 acre wood
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 6)){
-		if(settings["power_boost"] && current.power_boost > old.power_boost && vars.torn_page_power == 0){
+		if(current.power_boost > old.power_boost && vars.torn_page_power == 0){
 			vars.torn_page_power = 1;
 		}
-		if(settings["torn_page_1"] && current.nature_spark == 1 && old.nature_spark == 0 && vars.nature_spark == 0){
+		if(current.nature_spark == 1 && old.nature_spark == 0 && vars.nature_spark == 0){
 			vars.nature_spark = 1;
-			return true;
+			return settings["torn_page_1"];
 		}
-		if(settings["torn_page_2"] && current.mythril_shard > old.mythril_shard && vars.torn_page_mythril_shard == 0){
+		if(current.mythril_shard > old.mythril_shard && vars.torn_page_mythril_shard == 0){
 			vars.torn_page_mythril_shard = 1;
-			return true;
+			return settings["torn_page_2"];
 		}
-		if(settings["torn_page_3"] && current.stop_level > old.stop_level && vars.stopra == 0){
+		if(current.stop_level > old.stop_level && vars.stopra == 0){
 			vars.stopra = 1;
-			return true;
+			return settings["torn_page_3"];
 		}
-		if(settings["torn_page_4"] && current.mythril > old.mythril && vars.torn_page_mythril == 0){
+		if(current.mythril > old.mythril && vars.torn_page_mythril == 0){
 			vars.torn_page_mythril = 1;
-			return true;
+			return settings["torn_page_4"];
 		}
-		if(settings["torn_page_5"] && current.exp_ring > old.exp_ring && vars.exp_ring == 0){
+		if(current.exp_ring > old.exp_ring && vars.exp_ring == 0){
 			vars.exp_ring = 1;
-			return true;
+			return settings["torn_page_5"];
 		}
-		if(settings["seal_100_aw"] && old.room == 9 && current.room == 9 && vars.muddy_finish == 0){
+		if(old.room == 9 && current.room == 9 && vars.muddy_finish == 0){
 			vars.muddy_finish = 1;
 		}
 	}
 	// agrabah splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 8)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["pot"] && current.room == 19 && vars.pot == 0){
+			if(current.room == 19 && vars.pot == 0){
 				vars.pot = 1;
-				return true;
+				return settings["pot"];
 			}
-			if(settings["tiger"] && current.room == 1 && vars.tiger == 0){
+			if(current.room == 1 && vars.tiger == 0){
 				vars.tiger = 1;
-				return true;
+				return settings["tiger"];
 			}
-			if(settings["jafar"] && current.room == 16 && vars.jafar == 0){
+			if(current.room == 16 && vars.jafar == 0){
 				vars.jafar = 1;
-				return true;
+				return settings["jafar"];
 			}
-			if(settings["gj"] && current.room == 17 && vars.gj == 0){
+			if(current.room == 17 && vars.gj == 0){
 				vars.gj = 1;
-				return true;
+				return settings["gj"];
 			}
-			if(settings["kurt"] && current.room == 0 && current.scene == 13 && vars.kurt == 0){
+			if(current.room == 0 && current.scene == 13 && vars.kurt == 0){
 				vars.kurt = 1;
-				return true;
+				return settings["kurt"];
 			}
 		}
-		if(settings["save_al"] && current.room == 0 && current.scene == 4 && vars.save_al == 0){
+		if(current.room == 0 && current.scene == 4 && vars.save_al == 0){
 			vars.save_al = 1;
-			return true;
+			return settings["save_al"];
 		}
-		if(settings["carpet_escape"] && current.room == 1 && current.scene == 4 && vars.carpet_escape == 0){
+		if(current.room == 1 && current.scene == 4 && vars.carpet_escape == 0){
 			vars.carpet_escape = 1;
-			return true;
+			return settings["carpet_escape"];
 		}
 	}
 	// atlantica splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 9)){
-		if(settings["atlantica_1"] && vars.atlantica_1 == 0){
+		if(vars.atlantica_1 == 0){
 			if(current.torn_page_count > old.torn_page_count && current.room == 13 && vars.atl_torn_page == 0){
 				vars.atl_torn_page = 1;
 			}
 			if(current.room == 15 && vars.atl_torn_page == 1 && current.in_gummi > 0){
 				vars.atlantica_1 = 1;
-				return true;
+				return settings["atlantica_1"];
 			}
 		}
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["urs_1"] && current.room == 12 && current.scene == 2 && vars.ursula_1 == 0){
+			if(current.room == 12 && current.scene == 2 && vars.ursula_1 == 0){
 				vars.ursula_1 = 1;
-				return true;
+				return settings["urs_1"];
 			}
-			if(settings["urs_2"] && current.room == 16 && vars.ursula_2 == 0){
+			if(current.room == 16 && vars.ursula_2 == 0){
 				vars.ursula_2 = 1;
-				return true;
+				return settings["urs_2"];
 			}
 		}
 	}
 	// halloween town splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 10)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["lsb"] && current.room == 9 && vars.lsb == 0){
+			if(current.room == 9 && vars.lsb == 0){
 				vars.lsb = 1;
-				return true;
+				return settings["lsb"];
 			}
-			if(settings["oogie"] && current.room == 7 && vars.oogie == 0){
+			if(current.room == 7 && vars.oogie == 0){
 				vars.oogie = 1;
-				return true;
+				return settings["oogie"];
 			}
-			if(settings["oogie_manor"] && current.room == 8 && vars.oogie_manor == 0){
+			if(current.room == 8 && vars.oogie_manor == 0){
 				vars.oogie_manor = 1;
-				return true;
+				return settings["oogie_manor"];
 			}
 		}
-		if(settings["fmn"] && current.room == 10 && current.fmn == 0 && old.fmn == 1 && vars.fmn == 0){
+		if(current.room == 10 && current.fmn == 0 && old.fmn == 1 && vars.fmn == 0){
 			vars.fmn = 1;
-			return true;
+			return settings["fmn"];
 		}
-		if(settings["jb"] && current.room == 10 && current.jb == 0 && old.jb == 1 && vars.jb == 0){
+		if(current.room == 10 && current.jb == 0 && old.jb == 1 && vars.jb == 0){
 			vars.jb = 1;
-			return true;
+			return settings["jb"];
 		}
 	}
 	// olympus coliseum splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 11)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["cloud_1"] && current.room == 2 && current.scene == 0 && vars.cloud_1 == 0){
+			if(current.room == 2 && current.scene == 0 && vars.cloud_1 == 0){
 				vars.cloud_1 = 1;
-				return true;
+				return settings["cloud_1"];
 			}
-			if(settings["cerb_1"] && current.room == 2 && current.scene == 1 && vars.cerb_1 == 0){
+			if(current.room == 2 && current.scene == 1 && vars.cerb_1 == 0){
 				vars.cerb_1 = 1;
-				return true;
+				return settings["cerb_1"];
 			}
-			if(settings["pg_cup"] && current.room == 5 && current.scene == 0 && vars.pg_cup == 0){
+			if(current.room == 5 && current.scene == 0 && vars.pg_cup == 0){
 				vars.pg_cup = 1;
-				return true;
+				return settings["pg_cup"];
 			}
 			if(current.room == 2 && current.scene == 9 && vars.herc == 0){
-				if(settings["cloud_2"] && settings["herc_cup"]) {
-					if(vars.cloud_2 == 0) {
-						vars.cloud_2 = 1;
+				if(vars.cloud_2 == 0) {
+					vars.cloud_2 = 1;
+					if (settings["manual_back_step"]){
 						vars.back_split = "cloud2";
-					} else {
-						vars.herc = 1;
+					}
+					return settings["cloud2"];
+				} else {
+					if (!settings["manual_back_step"] && vars.deathcounter == 1) {
+						vars.deathcounter = 0;
+						return;
+					} else if (settings ["manual_back_step"]) {
 						vars.back_split = "";
 					}
-					return true;
-				} else if(settings["cloud_2"] && !settings["herc_cup"]) {
-					vars.back_split = "cloud2";
 					vars.herc = 1;
-					return true;
-				} else if(!settings["cloud_2"] && settings["herc_cup"]) {
-					if(vars.cloud_2 == 0) {
-						vars.cloud_2 = 1;
-						vars.back_split = "cloud2";
-						return false;
-					}
-					vars.back_split = "";
-					vars.herc = 1;
-					return true;
+					return settings["herc_cup"];
 				}
 			}
-			if(settings["hades_seed_39"] && current.room == 2 && current.scene == 11 && vars.hades_seed_39 == 0){
+			if(current.room == 2 && current.scene == 11 && vars.hades_seed_39 == 0){
 				vars.hades_seed_39 = 1;
-				return true;
+				return settings["hades_seed_39"];
 			}
-			if(settings["hades_seed_19"] && current.room == 6 && current.scene == 4 && vars.hades_seed_19 == 0){
+			if(current.room == 6 && current.scene == 4 && vars.hades_seed_19 == 0){
 				vars.hades_seed_19 = 1;
-				return true;
+				return settings["hades_seed_19"];
 			}
-			if(settings["hades_seed_9"] && current.room == 5 && current.scene == 13 && vars.hades_seed_9 == 0){
+			if(current.room == 5 && current.scene == 13 && vars.hades_seed_9 == 0){
 				vars.hades_seed_9 = 1;
-				return true;
+				return settings["hades_seed_9"];
 			}
-			if(settings["ice_titan"] && current.room == 6 && current.scene == 5 && vars.ice_titan == 0){
+			if(current.room == 6 && current.scene == 5 && vars.ice_titan == 0){
 				vars.ice_titan = 1;
-				return true;
+				return settings["ice_titan"];
 			}
-			if(settings["seph"] && current.room == 6 && current.scene == 6 && vars.seph == 0){
+			if(current.room == 6 && current.scene == 6 && vars.seph == 0){
 				vars.seph = 1;
-				return true;
+				return settings["seph"];
 			}
-			return true;
+			//return true; What fight is this returning?
 		}
-		if(settings["thunder"] && vars.thunder == 0){
+		if(vars.thunder == 0){
 			if(current.room == 1 && current.scene == 2 && old.room == 2 && vars.barrel_game == 0){
 				vars.barrel_game = 1;
-				return false;
 			}
 			if(current.room == 0 && current.scene == 1 && vars.barrel_game == 1 && current.in_gummi > 0){
 				vars.thunder = 1;
-				return true;
+				return settings["thunder"];
 			}
 		}
-		if(settings["phil_cup"] && current.gravity_level > old.gravity_level && vars.phil_cup == 0){
+		if(current.gravity_level > old.gravity_level && vars.phil_cup == 0){
 			vars.phil_cup = 1;
-			return true;
+			return settings["phil_cup"];
 		}
-		if(settings["phil_cup_solo"] && current.party_slot_1 == 255 && current.party_slot_2 == 255 && current.room == 2 && current.scene == 7 && vars.phil_cup_solo == 0){
+		if(current.party_slot_1 == 255 && current.party_slot_2 == 255 && current.room == 2 && current.scene == 7 && vars.phil_cup_solo == 0){
 			if(current.non_player_unit_count == 1 && old.non_player_unit_count == 0){
 				vars.phil_cup_solo = 1;
-				return true;
+				return settings["phil_cup_solo"];
 			}
 		}
-		if(settings["hades_seed_49"] && current.room == 5 && current.scene == 11 && current.colo_behemoth_health == 0 && old.colo_behemoth_health > 0 && vars.hades_seed_49 == 0){
+		if(current.room == 5 && current.scene == 11 && current.colo_behemoth_health == 0 && old.colo_behemoth_health > 0 && vars.hades_seed_49 == 0){
 			vars.hades_seed_49 = 1;
-			return true;
+			return settings["hades_seed_49"];
 		}
-		if(settings["hades_seed_29"] && current.room == 5 && current.scene == 4 && vars.hades_seed_29 == 0){
+		if(current.room == 5 && current.scene == 4 && vars.hades_seed_29 == 0){
 			if(current.non_player_unit_count == 2 && old.non_player_unit_count == 0 && vars.in_cloud_leon_fight == 0){
 				vars.in_cloud_leon_fight = 1;
 			}
 			if(vars.in_cloud_leon_fight == 1 && current.non_player_unit_count == 0 && old.non_player_unit_count == 1){
 				vars.hades_seed_29 = 1;
-				return true;
+				return settings["hades_seed_29"];
 			}
 		}
 	}
 	// monstro splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 12)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["pc"] && current.room == 4 && vars.pc == 0){
+			if(current.room == 4 && vars.pc == 0){
 				vars.pc = 1;
-				return true;
+				return settings["pc"];
 			}
-			if(settings["pc2"] && current.room == 2 && vars.pc2 == 0){
+			if(current.room == 2 && vars.pc2 == 0){
 				vars.pc2 = 1;
-				return true;
+				return settings["pc2"];
 			}
 		}
 	}
@@ -572,156 +550,155 @@ split
 	// neverland splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 13)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["anti"] && current.room == 6 && vars.anti == 0){
+			if(current.room == 6 && vars.anti == 0){
 				vars.anti = 1;
-				return true;
+				return settings["anti"];
 			}
-			if(settings["hook"] && current.room == 8 && vars.hook == 0){
+			if(current.room == 8 && vars.hook == 0){
 				vars.hook = 1;
-				return true;
+				return settings["hook"];
 			}
-			if(settings["nap_time"] && current.room == 9 && current.scene == 1 && vars.nap == 0){
+			if(current.room == 9 && current.scene == 1 && vars.nap == 0){
 				vars.nap = 1;
-				return true;
+				return settings["nap_time"];
 			}
 		}
-		if(settings["ship"] && (current.gummi_start == 10 || current.gummi_start == 9) && current.gummi_dest == 13 && current.cutscene && vars.ship == 0){
+		if((current.gummi_start == 10 || current.gummi_start == 9) && current.gummi_dest == 13 && current.cutscene && vars.ship == 0){
 			vars.ship = 1;
-			return true;
+			return settings["ship"];
 		}
 	}
 	// hollow bastion splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 15)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["riku"] && current.room == 4 && vars.riku == 0){
+			if(current.room == 4 && vars.riku == 0){
 				vars.riku = 1;
-				return true;
+				return settings["riku"];
 			}
-			if(settings["mal"] && current.room == 11 && vars.mal == 0){
+			if(current.room == 11 && vars.mal == 0){
 				vars.mal = 1;
-				return true;
+				return settings["mal"];
 			}
-			if(settings["dragon"] && current.room == 12 && current.scene == 0 && vars.dragon == 0){
+			if(current.room == 12 && current.scene == 0 && vars.dragon == 0){
 				vars.dragon = 1;
-				return true;
+				return settings["dragon"];
 			}
-			if(settings["riku2"] && current.room == 14 && vars.riku2 == 0){
+			if(current.room == 14 && vars.riku2 == 0){
 				vars.riku2 = 1;
-				return true;
+				return settings["riku2"];
 			}
-			if(settings["behemoth"] && current.room == 15 && vars.behemoth == 0){
+			if(current.room == 15 && vars.behemoth == 0){
 				vars.behemoth = 1;
-				return true;
+				return settings["behemoth"];
 			}
 		}
-		if(settings["emblem"] && old.room == 11 && current.room == 4 && current.scene == 13 && vars.emblem == 0){
+		if(old.room == 11 && current.room == 4 && current.scene == 13 && vars.emblem == 0){
 			vars.emblem = 1;
-			return true;
+			return settings["emblem"];
 		}
-		if(settings["dumbo_1"] && current.room == 3 && current.scene == 13 && vars.dumbo_1 == 0 && current.summonload && vars.summontimer > 30){
+		if(current.room == 3 && current.scene == 13 && vars.dumbo_1 == 0 && current.summonload && vars.summontimer > 30){
 			vars.dumbo_1 = 1;
-			return true;
+			return settings["dumbo_1"];
 		}
-		if(settings["dumbo_2"] && current.room == 1 && current.scene == 14 && vars.dumbo_2 == 0 && current.summonload && vars.summontimer > 30){
+		if(current.room == 1 && current.scene == 14 && vars.dumbo_2 == 0 && current.summonload && vars.summontimer > 30){
 			vars.dumbo_2 = 1;
-			return true;
+			return settings["dumbo_2"];
 		}
-		if(settings["dumbo_3"] && current.room == 3 && current.scene == 14 && vars.dumbo_3 == 0 && current.summonload && vars.summontimer > 30){
+		if(current.room == 3 && current.scene == 14 && vars.dumbo_3 == 0 && current.summonload && vars.summontimer > 30){
 			vars.dumbo_3 = 1;
-			return true;
+			return settings["dumbo_3"];
 		}
-		if(settings["xemnas"] && current.room == 12 && current.scene == 2 && current.exp_necklace > old.exp_necklace && vars.xemnas == 0){
+		if(current.room == 12 && current.scene == 2 && current.exp_necklace > old.exp_necklace && vars.xemnas == 0){
 			vars.xemnas = 1;
-			return true;
+			return settings["xemnas"];
 		}
 	}
 	// end of world splits
 	if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 16)){
 		if(current.fightend == 2 && old.fightend == 0){
-			if(settings["cher"] && current.room == 26 && vars.cher == 0){
+			if(current.room == 26 && vars.cher == 0){
 				vars.cher = 1;
-				return true;
+				return settings["cher"];
 			}
-			if(settings["a1"] && current.room == 30 && vars.a1 == 0){
+			if(current.room == 30 && vars.a1 == 0){
 				vars.a1 = 1;
-				return true;
+				return settings["a1"];
 			}
-			if(settings["ds3"] && current.room == 30 && vars.ds3 == 0){
-				if(!settings["a1"] && vars.a1 == 0){
-					vars.a1 = 1;
-					return false;
-				}
+			if(current.room == 30 && vars.ds3 == 0 && vars.a1 == 1){
 				vars.ds3 = 1;
-				vars.back_split = "ds3";
-				return true;
+				if (settings["manual_back_step"]) {
+					vars.back_split = "ds3";
+				}
+				return settings["ds3"];
 			}
-			if(settings["a2"] && current.room == 30 && vars.a2 == 0){
-				if(!settings["ds3"] && vars.ds3 == 0){
-					vars.ds3 = 1;
-					return false;
+			if(current.room == 30 && vars.a2 == 0 && vars.ds3 == 1){
+				if (!settings["manual_back_step"] && vars.deathcounter == 1) {
+					vars.deathcounter = 0;
+					return;
+				} else if (settings ["manual_back_step"]) {
+					vars.back_split = "";
 				}
 				vars.a2 = 1;
-				vars.back_split = "";
-				return true;
+				return settings["a2"];
 			}
-			if(settings["a3"] && current.room == 33 && vars.a3 == 0){
+			if(current.room == 33 && vars.a3 == 0){
 				vars.a3 = 1;
-				return true;
+				return settings["a3"];
 			}
-			if(settings["sc"] && current.room == 36 && vars.sc == 0){
+			if(current.room == 36 && vars.sc == 0){
 				vars.sc = 1;
-				return true;
+				return settings["sc"];
 			}
-			if(settings["dbc"] && current.room == 37 && vars.dbc == 0){
+			if(current.room == 37 && vars.dbc == 0){
 				vars.dbc = 1;
-				return true;
+				return settings["dbc"];
 			}
-			if(settings["face"] && current.room == 33 && vars.face == 0){
+			if(current.room == 33 && vars.face == 0 && vars.a3 == 1){
 				vars.face = 1;
-				return true;
+				return settings["face"];
 			}
-			if(settings["inc"] && current.room == 38 && vars.inc == 0){
+			if(current.room == 38 && vars.inc == 0){
 				vars.inc = 1;
-				return true;
+				return settings["inc"];
 			}
-			if(settings["mc"] && current.room == 33 && vars.mc == 0){
+			if(current.room == 33 && vars.mc == 0 && vars.face == 1){
 				vars.mc = 1;
-				return true;
+				return settings["mc"];
 			}
-			if(current.room == 33 && vars.final_fight == 0){
+			if(current.room == 33 && vars.final_fight == 0 && vars.mc == 1){
 				vars.final_fight = 1;
-				return true;
+				return settings["a4"];
 			}
 		}
-		if(settings["arch"] && current.room == 14 && vars.arch == 0){
+		if(current.room == 14 && vars.arch == 0){
 			vars.arch = 1;
-			return true;
+			return settings["arch"];
 		}
-		if(settings["oc"] && old.room == 18 && current.room == 15 && vars.oc == 0){
+		if(old.room == 18 && current.room == 15 && vars.oc == 0){
 			vars.oc = 1;
-			return true;
+			return settings["oc"];
 		}
-		if(settings["atl"] && old.room == 21 && current.room == 15 && vars.atl == 0){
+		if(old.room == 21 && current.room == 15 && vars.atl == 0){
 			vars.atl = 1;
-			return true;
+			return settings["atl"];
 		}
-		if(settings["hbp"] && old.room == 25 && current.room == 15 && vars.hbp == 0){
+		if(old.room == 25 && current.room == 15 && vars.hbp == 0){
 			vars.hbp = 1;
-			return true;
+			return settings["hbp"];
 		}
-		if(settings["behemoth_3"] && current.room == 28 && vars.behemoth_3 == 0 && (current.behemoth_3_health == 0 && old.behemoth_3_health > 0)){
+		if(current.room == 28 && vars.behemoth_3 == 0 && (current.behemoth_3_health == 0 && old.behemoth_3_health > 0)){
 			vars.behemoth_3 = 1;
 		 	vars.back_split = "be3";
-			return true;
+			return settings["behemoth_3"];
 		}
-		if(settings["finalrest"] && current.room == 29 && vars.finalrest == 0){
+		if(current.room == 29 && vars.finalrest == 0){
 			vars.finalrest = 1;
 			vars.back_split = "";
-			return true;
+			return settings["finalrest"];
 		}
-		if(settings["artillery"] && old.room == 33 && current.room == 37 && vars.artillery == 0){
+		if(old.room == 33 && current.room == 37 && vars.artillery == 0){
 			vars.artillery = 1;
-			return true;
+			return settings["artillery"];
 		}
 	}
 	// settings
@@ -754,16 +731,20 @@ split
 			vars.ds3 = 0;
 		}
 	}
-	// WIP general fight end splits
+	if (current.hp == 0 && ((vars.clayton_1 == 1 && vars.clayton_2 == 0) || (vars.fake_guard == 1 && vars.oppo == 0) || (vars.ds3 == 1 && vars.a2 == 0))) {
+		vars.deathcounter = 1;
+	}
+	/*WIP general fight end splits 
+	- Commenting out for bug prevention
 	if(current.fightend == 2 && old.fightend == 0){
 		if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 9)){
 			return true;
-		}
-		else if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 11)){
+		} else if(vars.checkWorldValue(current.w1, current.w2, current.w3, current.w4, current.w5, current.w6, current.w7, current.w8, 11)){
 			return true;
 		}
 	}
 	return false;
+	*/
 }
 
 exit
@@ -876,6 +857,7 @@ init
 	vars.mc = 0;
 	vars.final_fight = 0;
 	vars.back_split = "";
+	vars.deathcounter = 0;
 	timer.IsGameTimePaused = false;
 	Func <ushort, ushort, ushort, ushort, ushort, ushort, ushort, ushort, int, bool> checkWorldValue = (ushort a, ushort b, ushort c, ushort d, ushort e, ushort f, ushort g, ushort h, int actual) => {
 		return a == actual || b == actual || c == actual || d == actual || e == actual || f == actual || f == actual || g == actual || h == actual;


### PR DESCRIPTION
+ Double split prevention will always toggle, and will return the split toggle of setting[] instead.
+ Added Ansem 4, stopped it from splitting as fights prior to it as they shared the same room.
+ Fixed the logic on fights like Clayton, Ansem 2, etc. for those who don't unsplit as well as resplit