### PR TITLE
Fix logic for toggles

### DIFF
--- a/1FMMods/scripts/1fmFasterAnims.lua
+++ b/1FMMods/scripts/1fmFasterAnims.lua
@@ -26,11 +26,11 @@ function inTimedEvent()
 end
 
 function inSummoning()
-	return ReadInt(summoning) == 0 or summonSpeedup
+	return ReadInt(summoning) == 0 and summonSpeedup
 end
 
 function inScene()
-	return (ReadFloat(soraHUD) < 1 and ReadInt(inCutscene) > 0 and ReadInt(inCutscene) ~= 8  and ReadInt(skippable) ~= 1025) or sceneSpeedup
+	return (ReadFloat(soraHUD) < 1 and ReadInt(inCutscene) > 0 and ReadInt(inCutscene) ~= 8  and ReadInt(skippable) ~= 1025) and sceneSpeedup
 end
 
 function inDIBoatSide()


### PR DESCRIPTION
Previously the code used logical or instead of logical and, meaning they would always act as though the player was in a text scene or summon scene respectively if those settings were turned on.