### PR TITLE
Fix inSummoning function logic

### DIFF
--- a/1FMMods/scripts/1fmFasterAnims.lua
+++ b/1FMMods/scripts/1fmFasterAnims.lua
@@ -26,7 +26,7 @@ function inTimedEvent()
 end
 
 function inSummoning()
-	return ReadInt(summoning) == 0 and summonSpeedup
+	return ReadInt(summoning) == 0 or summonSpeedup
 end
 
 function inScene()


### PR DESCRIPTION
Revert to or as the and version disables the use of the boolean as intended.